### PR TITLE
Fix command line option invoking nosetests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Usage
 
   --with-html           Enable plugin HtmlOutput:  Output test results as
                         pretty html.  [NOSE_WITH_HTML]
-  --html-file=FILE      Path to html file to store the report in. Default is
+  --html-report=FILE    Path to html file to store the report in. Default is
                         nosetests.html in the working directory
   --html-report-template=FILE      Path to jinja2 file to get the report template from. Default is
                         templates/report.html from the package working directory

--- a/tests/test_nose_htmloutput.py
+++ b/tests/test_nose_htmloutput.py
@@ -8,7 +8,7 @@ TIMEOUT = 10
 
 def test_sample():
     with TestProcess(
-        'coverage', 'run', 'tests/nosetests.py', '--verbose', '--with-html', '--html-file=sample.html',
+        'coverage', 'run', 'tests/nosetests.py', '--verbose', '--with-html', '--html-report=sample.html',
         'tests/test_sample.py'
     ) as proc:
         with dump_on_error(proc.read):


### PR DESCRIPTION
#### Description

When nosetests is invoked by running `tox`, the `--html-file` option is included, while this has been renamed to `--html-report`. Therefore, tests fail.
#### Documentation

README.rst was outdated regarding the renaming of such option.
#### Testing

Despite this fix, unittests run by `tox` still fail (as report file `sample.html` has no path, `os.makedirs()` raises an error trying to create `''` directory).
#### Issue

No issues are enabled (apart from pull requests), so it hasn't been possible to register this bug.
