### PR TITLE
Fix version after incomplete bump

### DIFF
--- a/src/nose_html_reporting/__init__.py
+++ b/src/nose_html_reporting/__init__.py
@@ -13,7 +13,7 @@ from nose.exc import SkipTest
 from nose.plugins import Plugin
 import sys
 
-__version__ = '0.1.0'
+__version__ = '0.2.1'
 
 TEST_ID = re.compile(r'^(.*?)(\(.*\))$')
 


### PR DESCRIPTION
#### Description

There was an inconsistency in version numbers. While `setup.py` and `.bumpversion.cfg` include _0.2.1_ as current version, `__init__.py` was still including the former _0.1.0_ version number.

It seems that versions have been incremented "manually" instead of by running the `bumpversion` command. For example, if next planned version were _0.2.2_, then _patch_ component of the version should be incremented, so we'd run:

```
$ bumpversion --new-version=0.2.2 patch
```

letting this tool do all the work, even the commit with a message "Bump version: 0.2.1 → 0.2.2".
#### Release 0.2.1

As a new release has been made available today (see _changelog_) and package is already released in [PyPI](https://pypi.python.org/pypi/nose-html-reporting), I'd suggest drafting current `master` contents as a new release in GitHub (with its corresponding tag `v0.2.1`) and, **after that**, bumping a new version (for example, 0.2.2) in `master`.
#### Issue

No issues are enabled (apart from pull requests), so it hasn't been possible to register this bug.
