### PR TITLE
Fix decode bug in python3

### DIFF
--- a/src/nose_html_reporting/__init__.py
+++ b/src/nose_html_reporting/__init__.py
@@ -298,7 +298,7 @@ class HtmlReport(Plugin):
         })
 
     def _format_output(self, o):
-        if isinstance(o, str):
+        if isinstance(o, bytes):
             return o.decode('latin-1')
         else:
             return o


### PR DESCRIPTION
Only decode if `bytes`, not if `str`.
Should work in both python 2 and 3, since `isinstance('a', bytes)` is `True` in python 2.